### PR TITLE
Add cargo to the build dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ make build-docker && make install
 * First install build dependencies
 ```
 # dnf/rpm based distributions
-sudo dnf install libinput-devel
+sudo dnf install cargo libinput-devel
 
 # apt/deb based distributions
-sudo apt install libinput-dev
+sudo apt install cargo libinput-dev
 ```
 * Then build and install
 ```


### PR DESCRIPTION
This project worked great once installed.  However, during installation I got an error about `cargo` not being a known directory.  After running `sudo apt install -y cargo` I was able to complete the installation.  By adding it explicitly to the README under build dependencies this should help the next person avoid that.