### PR TITLE
Portable systemd service file

### DIFF
--- a/gesture_improvements_gesture_daemon.service
+++ b/gesture_improvements_gesture_daemon.service
@@ -5,6 +5,7 @@ StartLimitInterval=0
 
 [Service]
 Type=simple
-ExecStart=@HOME/.local/bin/gesture_improvements_gesture_daemon
+ExecStart=%h/.local/bin/gesture_improvements_gesture_daemon
 Restart=always
 RestartSec=1s
+

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 
 echo "Installing ..."
-sed -i "s#@HOME#${HOME}#g" gesture_improvements_gesture_daemon.service
 mkdir -vp ~/.config/systemd/user ~/.local/bin
 cp -vf gesture_improvements_gesture_daemon.service ~/.config/systemd/user
 cp -vf target/release/gesture_improvements_gesture_daemon ~/.local/bin
@@ -22,3 +21,4 @@ else
 fi
 
 echo "Service will be automatically started by extension."
+


### PR DESCRIPTION
Previously "@HOME" was a dummy variable which was supposed to be replaced with absolute path during installation. systemd supports home directory specifier (%h) since version 187* (2012 year) so let's use it instead.
* https://github.com/systemd/systemd/blob/main/NEWS#L14960