### PR TITLE
Update README.md build dependencies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ make build-docker && make install
 * First install build dependencies
 ```
 # dnf/rpm based distributions
-sudo dnf install libinput-devel
+sudo dnf install libinput-devel cargo rust-libudev-sys-devel
 
 # apt/deb based distributions
-sudo apt install libinput-dev
+sudo apt install libinput-dev cargo librust-libudev-sys-dev
 ```
 * Then build and install
 ```


### PR DESCRIPTION
# Update build dependencies.

Added packages `cargo` and `libudev` as requirements for build/installation.

* Tested build on `Fedora 38` for `dnf/rpm` related distros.

* Tested build on `Ubuntu 23.04` for `apt/dev` related dsitros.